### PR TITLE
Add support for Apple event callbacks and arbitrary plist rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ dummy = []
 [dependencies]
 time = "0.1"
 log = {version = "0.4", optional = true }
+dirs = "1.0.4"
 
 [dependencies.log4rs]
 version = "0.8"

--- a/examples/register_url.rs
+++ b/examples/register_url.rs
@@ -19,7 +19,6 @@ use fruitbasket::InstallDir;
 use fruitbasket::RunPeriod;
 use fruitbasket::FruitError;
 use fruitbasket::FruitCallbackKey;
-use std::time::Duration;
 use std::path::PathBuf;
 
 #[macro_use]

--- a/examples/register_url.rs
+++ b/examples/register_url.rs
@@ -1,0 +1,114 @@
+/// Example that launches as Mac App with custom URL scheme handler
+///
+/// In one terminal, build and run:
+///
+/// $ cargo build --features=logging --examples
+/// $ ./target/debug/examples/register_url && tail -f ~/.fruitbasket_register_url.log
+///
+/// In a second terminal, open custom URL:
+///
+/// $ open fruitbasket://test
+///
+/// Log output will show that the example has received and printed the custom URL.
+///
+extern crate fruitbasket;
+use fruitbasket::ActivationPolicy;
+use fruitbasket::Trampoline;
+use fruitbasket::FruitApp;
+use fruitbasket::InstallDir;
+use fruitbasket::RunPeriod;
+use fruitbasket::FruitError;
+use fruitbasket::FruitCallbackKey;
+use std::time::Duration;
+use std::path::PathBuf;
+
+#[macro_use]
+extern crate log;
+
+fn main() {
+    let _ = fruitbasket::create_logger(".fruitbasket_register_url.log", fruitbasket::LogDir::Home, 5, 2).unwrap();
+
+    // Find the icon file from the Cargo project dir
+    let icon = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples").join("icon.png");
+
+    // Re-launch self in an app bundle if not already running from one.
+    info!("Executable must run from App bundle.  Let's try:");
+    let mut app = match Trampoline::new("fruitbasket_register_url", "fruitbasket", "com.trevorbentley.fruitbasket_register_url")
+        .version("2.1.3")
+        .icon("fruitbasket.icns")
+        .plist_key("CFBundleSpokenName","\"fruit basket\"")
+        .plist_keys(&vec![
+            ("LSMinimumSystemVersion", "10.12.0"),
+            ("LSBackgroundOnly", "1"),
+        ])
+        // Register "fruitbasket://" and "fbasket://" URL schemes in Info.plist
+        .plist_raw_string("
+CFBundleURLTypes = ( {
+  CFBundleTypeRole = \"Viewer\";
+  CFBundleURLName = \"Fruitbasket Example URL\";
+  CFBundleURLSchemes = (\"fruitbasket\", \"fbasket\");
+} );\n".into())
+        .resource(icon.to_str().unwrap())
+        .build(InstallDir::Temp) {
+            Err(FruitError::UnsupportedPlatform(_)) => {
+                info!("This is not a Mac.  App bundling is not supported.");
+                info!("It is still safe to use FruitApp::new(), though the dummy app will do nothing.");
+                FruitApp::new()
+            },
+            Err(FruitError::IOError(e)) => {
+                info!("IO error! {}", e);
+                std::process::exit(1);
+            },
+            Err(FruitError::GeneralError(e)) => {
+                info!("General error! {}", e);
+                std::process::exit(1);
+            },
+            Ok(app) => app,
+        };
+
+    // App is guaranteed to be running in a bundle now!
+
+    // Make it a regular app in the dock.
+    // Note: Because 'LSBackgroundOnly' is set to true in the Info.plist, the
+    // app will launch backgrounded and will not take focus.  If we only did
+    // that, the app would stay in 'Prohibited' mode and would not create a dock
+    // icon.  By overriding the activation policy now, it will stay background
+    // but create the Dock and menu bar entries.  This basically implements a
+    // "pop-under" behavior.
+    app.set_activation_policy(ActivationPolicy::Regular);
+
+    // Register a callback for when the ObjC application finishes launching
+    let stopper = app.stopper();
+    app.register_callback(FruitCallbackKey::Method("applicationWillFinishLaunching:"),
+                          Box::new(move |_event| {
+                              info!("applicationDidFinishLaunching.");
+                              stopper.stop();
+                          }));
+
+    // Run until callback is called
+    info!("Spawned process started.  Run until applicationDidFinishLaunching.");
+    let _ = app.run(RunPeriod::Forever);
+
+    info!("Application launched.  Registering URL callbacks.");
+    // Register a callback to get receive custom URL schemes from any Mac program
+    app.register_apple_event(fruitbasket::kInternetEventClass, fruitbasket::kAEGetURL);
+    let stopper = app.stopper();
+    app.register_callback(FruitCallbackKey::Method("handleEvent:withReplyEvent:"),
+                          Box::new(move |event| {
+                              // Event is a raw NSAppleEventDescriptor.
+                              // Fruitbasket has a parser for URLs.  Call that to get the URL:
+                              let url: String = fruitbasket::parse_url_event(event);
+                              info!("Received URL: {}", url);
+                              stopper.stop();
+                          }));
+
+    // Run 'forever', until the URL callback fires
+    info!("Spawned process running!");
+    let _ = app.run(RunPeriod::Forever);
+    info!("Run loop stopped after URL callback.");
+
+    // Cleanly terminate
+    fruitbasket::FruitApp::terminate(0);
+    info!("This will not print.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,16 @@ pub const FORBIDDEN_PLIST: &'static [&'static str] = & [
     "CFBundleVersion",
 ];
 
+/// Apple kInternetEventClass constant
+#[allow(non_upper_case_globals)]
+pub const kInternetEventClass: u32 = 0x4755524c;
+/// Apple kAEGetURL constant
+#[allow(non_upper_case_globals)]
+pub const kAEGetURL: u32 = 0x4755524c;
+/// Apple keyDirectObject constant
+#[allow(non_upper_case_globals)]
+pub const keyDirectObject: u32 = 0x2d2d2d2d;
+
 #[cfg(all(target_os = "macos", not(feature="dummy")))]
 mod osx;
 
@@ -100,6 +110,20 @@ pub use osx::FruitApp;
 #[cfg(all(target_os = "macos", not(feature="dummy")))]
 pub use osx::Trampoline;
 
+#[cfg(all(target_os = "macos", not(feature="dummy")))]
+pub use osx::FruitObjcCallback;
+
+#[cfg(all(target_os = "macos", not(feature="dummy")))]
+pub use osx::FruitCallbackKey;
+
+#[cfg(all(target_os = "macos", not(feature="dummy")))]
+pub use osx::parse_url_event;
+
+#[cfg(any(not(target_os = "macos"), feature="dummy"))]
+pub enum FruitCallbackKey {}
+
+#[cfg(any(not(target_os = "macos"), feature="dummy"))]
+pub type FruitObjcCallback = Box<Fn(*mut u64)>;
 
 /// Main interface for controlling and interacting with the AppKit app
 ///
@@ -118,6 +142,10 @@ impl FruitApp {
         let (tx,rx) = channel();
         FruitApp{ tx: tx, rx: rx}
     }
+    /// Docs in OS X build.
+    pub fn register_callback(&mut self, key: FruitCallbackKey, cb: FruitObjcCallback) {}
+    /// Docs in OS X build.
+    pub fn register_apple_event(&mut self, class: u32, id: u32) {}
     /// Docs in OS X build.
     pub fn set_activation_policy(&self, _policy: ActivationPolicy) {}
     /// Docs in OS X build.
@@ -155,6 +183,9 @@ impl FruitApp {
     /// Docs in OS X build.
     pub fn bundled_resource_path(_name: &str, _extension: &str) -> Option<String> { None }
 }
+
+#[cfg(any(not(target_os = "macos"), feature="dummy"))]
+pub fn parse_url_event(event: *mut Object) -> String { "".into() }
 
 /// API to move the executable into a Mac app bundle and relaunch (if necessary)
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use std::sync::mpsc::Receiver;
 use std::thread;
 
 extern crate time;
+extern crate dirs;
 
 #[cfg(all(target_os = "macos", not(feature="dummy")))]
 #[macro_use]
@@ -364,7 +365,7 @@ pub fn create_logger(filename: &str,
     use self::log4rs::config::{Appender, Config, Logger, Root};
 
     let log_path = match dir {
-        LogDir::Home => format!("{}/{}", std::env::home_dir().unwrap().display(), filename),
+        LogDir::Home => format!("{}/{}", dirs::home_dir().unwrap().display(), filename),
         LogDir::Temp => format!("{}/{}", std::env::temp_dir().display(), filename),
         LogDir::Custom(s) => format!("{}/{}", s, filename),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,16 @@ pub use osx::FruitCallbackKey;
 pub use osx::parse_url_event;
 
 #[cfg(any(not(target_os = "macos"), feature="dummy"))]
-pub enum FruitCallbackKey {}
+/// Docs in OS X build.
+pub enum FruitCallbackKey {
+    /// Docs in OS X build.
+    Method(&'static str),
+    /// Docs in OS X build.
+    Object(*mut u64),
+}
 
 #[cfg(any(not(target_os = "macos"), feature="dummy"))]
+/// Docs in OS X build.
 pub type FruitObjcCallback = Box<Fn(*mut u64)>;
 
 /// Main interface for controlling and interacting with the AppKit app
@@ -144,9 +151,9 @@ impl FruitApp {
         FruitApp{ tx: tx, rx: rx}
     }
     /// Docs in OS X build.
-    pub fn register_callback(&mut self, key: FruitCallbackKey, cb: FruitObjcCallback) {}
+    pub fn register_callback(&mut self, _key: FruitCallbackKey, _cb: FruitObjcCallback) {}
     /// Docs in OS X build.
-    pub fn register_apple_event(&mut self, class: u32, id: u32) {}
+    pub fn register_apple_event(&mut self, _class: u32, _id: u32) {}
     /// Docs in OS X build.
     pub fn set_activation_policy(&self, _policy: ActivationPolicy) {}
     /// Docs in OS X build.
@@ -186,7 +193,8 @@ impl FruitApp {
 }
 
 #[cfg(any(not(target_os = "macos"), feature="dummy"))]
-pub fn parse_url_event(event: *mut Object) -> String { "".into() }
+/// Docs in OS X build.
+pub fn parse_url_event(_event: *mut u64) -> String { "".into() }
 
 /// API to move the executable into a Mac app bundle and relaunch (if necessary)
 ///
@@ -212,6 +220,8 @@ impl Trampoline {
     pub fn plist_key(&mut self, _key: &str, _value: &str) -> &mut Self { self }
     /// Docs in OS X build.
     pub fn plist_keys(&mut self, _pairs: &Vec<(&str,&str)>) -> &mut Self { self }
+    /// Docs in OS X build.
+    pub fn plist_raw_string(&mut self, _s: String) -> &mut Self { self }
     /// Docs in OS X build.
     pub fn resource(&mut self, _file: &str) -> &mut Self { self }
     /// Docs in OS X build.

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -34,6 +34,11 @@
 //! If uncertain, use a `Trampoline`.  You can hit very strange behavior when running
 //! Cocoa apps outside of an app bundle.
 #![deny(missing_docs)]
+
+// Temporarily (mmmmhmm...) disable deprecated function warnings, because objc macros
+// throw tons of them in rustc 1.34-nightly when initializing atomic uints.
+#![allow(deprecated)]
+
 use std;
 use std::thread;
 use std::time::Duration;
@@ -55,6 +60,8 @@ use super::DEFAULT_PLIST;
 use super::FORBIDDEN_PLIST;
 
 extern crate time;
+
+extern crate dirs;
 
 extern crate objc;
 use objc::runtime::Object;
@@ -424,7 +431,7 @@ impl Trampoline {
             let install_dir: PathBuf = match dir {
                 InstallDir::Temp => std::env::temp_dir(),
                 InstallDir::SystemApplications => PathBuf::from("/Applications/"),
-                InstallDir::UserApplications => std::env::home_dir().unwrap().join("Applications/"),
+                InstallDir::UserApplications => dirs::home_dir().unwrap().join("Applications/"),
                 InstallDir::Custom(dir) => std::fs::canonicalize(PathBuf::from(dir))?,
             };
             info!("Install dir: {:?}", install_dir);

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -540,7 +540,7 @@ impl FruitApp {
                 }
                 let mode = self.run_mode;
                 let event: *mut Object = msg_send![self.app,
-                                                   nextEventMatchingMask: -1
+                                                   nextEventMatchingMask: 0xffffffffffffffffu64
                                                    untilDate: nil
                                                    inMode: mode
                                                    dequeue: 1];


### PR DESCRIPTION
Allow registering for Apple callback events, plus some NSApplication delegate events.  Also allow injecting arbitrary strings into the Info.plist file.  Combined, these allow things like registering your app for custom URL schemes.