### PR TITLE
Reduce deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ dummy = []
 
 [dependencies]
 time = "0.1"
-log = {version = "0.4", optional = true }
-dirs = "1.0.4"
+log = {version = "0.4", optional = true, default-features = false, features = ["std"] }
+dirs = "^2.0"
 
 [dependencies.log4rs]
 version = "0.8"
 optional = true
-features = ["rolling_file_appender"]
+default-features = false
+features = ["console_appender","rolling_file_appender", "compound_policy", "fixed_window_roller", "size_trigger"]
 
 [dev-dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dummy = []
 [dependencies]
 time = "0.1"
 log = {version = "0.4", optional = true, default-features = false, features = ["std"] }
-dirs = "^2.0"
+dirs = "2.0"
 
 [dependencies.log4rs]
 version = "0.8"
@@ -29,7 +29,7 @@ features = ["console_appender","rolling_file_appender", "compound_policy", "fixe
 log = "0.4"
 
 [target."cfg(target_os = \"macos\")".dependencies]
-objc-foundation = "0.1.1"
+objc-foundation = "0.1"
 objc_id = "0.1"
 
 [target."cfg(target_os = \"macos\")".dependencies.objc]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl Error for FruitError {
     fn description(&self) -> &str {
         "Hmm"
     }
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -119,7 +119,7 @@ pub struct FruitApp {
 }
 
 /// A boxed Fn type for receiving Rust callbacks from ObjC events
-pub type FruitObjcCallback = Box<Fn(*mut Object)>;
+pub type FruitObjcCallback = Box<dyn Fn(*mut Object)>;
 
 /// Key into the ObjC callback hash map
 ///


### PR DESCRIPTION
Remove unused features from logging crates to reduce transitive dependency count.