### PR TITLE
Fix compilation in rust 1.38

### DIFF
--- a/src/osx.rs
+++ b/src/osx.rs
@@ -586,7 +586,7 @@ impl FruitApp {
             let cls = Class::get("NSAppleEventManager").unwrap();
             let manager: *mut Object = msg_send![cls, sharedAppleEventManager];
             let objc = (*self.objc).take();
-            let _ = msg_send![manager,
+            let _:() = msg_send![manager,
                               setEventHandler: objc
                               andSelector: sel!(handleEvent:withReplyEvent:)
                               forEventClass: class


### PR DESCRIPTION
Fixes this error when compiling:

```
error[E0282]: type annotations needed
   --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/fruitbasket-0.8.0/src/osx.rs:589:13
    |
589 | /             msg_send![manager,
590 | |                               setEventHandler: objc
591 | |                               andSelector: sel!(handleEvent:withReplyEvent:)
592 | |                               forEventClass: class
593 | |                               andEventID: id];
    | |                                              ^
    | |                                              |
    | |______________________________________________cannot infer type
    |                                                consider giving `result` a type
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error: aborting due to previous error
```