### PR TITLE
Make self_bundle public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,12 @@ impl Trampoline {
     /// Docs in OS X build.
     pub fn resources(&mut self, _files: &Vec<&str>) -> &mut Self{ self }
     /// Docs in OS X build.
-    pub fn build(&mut self, _dir: InstallDir) -> Result<FruitApp, FruitError> {
+    pub fn build(&mut self, dir: InstallDir) -> Result<FruitApp, FruitError> {
+        self.self_bundle(dir)?;
+        unreachable!()
+    }
+    /// Docs in OS X build.
+    pub fn self_bundle(&mut self, _dir: InstallDir) -> Result<(), FruitError> {
         Err(FruitError::UnsupportedPlatform("fruitbasket disabled or not supported on this platform.".to_string()))
     }
     /// Docs in OS X build.

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -421,7 +421,11 @@ impl Trampoline {
             ident != nil
         }
     }
-    fn self_bundle(&self, dir: InstallDir) -> Result<(), FruitError> {
+    /// Same as `build`, but does not construct a FruitApp if successful.
+    ///
+    /// Useful if you'd like to use a GUI library, such as libui, and don't
+    /// want fruitbasket to try to initialize anything for you. Bundling only.
+    pub fn self_bundle(&self, dir: InstallDir) -> Result<(), FruitError> {
         unsafe {
             if Self::is_bundled() {
                 return Ok(());


### PR DESCRIPTION
Some people don't want or need a FruitApp and in some cases it can cause issues trying to use other GUI libraries such as libui. https://github.com/rust-native-ui/libui-rs/issues/97

This PR exposes the `self_bundle` method (on `Trampoline`) for public use, so that fruitbasket doesn't have to instantiate the NSApplication and other related classes, but leave it to the user instead.

Without this change, fruitbasket creates the NSApplication (and certain other objects) before libui can get to it, and then libui tries to initialize things again, which causes an uncaught exception (oh no!), and then the event loops don't work correctly unless you run them both at once and _only in a specific order_.

With this change, if you don't choose to use the `FruitApp`, fruitbasket has no event loop for you to deal with because it only deals with bundling, which allows libui to absolutely fly.