### PR TITLE
Remove usage of deprecated .description()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ impl std::fmt::Display for FruitError {
 }
 impl From<std::io::Error> for FruitError {
     fn from(error: std::io::Error) -> Self {
-        FruitError::IOError(error.description().to_owned())
+        FruitError::IOError(error.to_string())
     }
 }
 impl Error for FruitError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ pub fn create_logger(filename: &str,
         .unwrap();
     match log4rs::init_config(config) {
         Ok(_) => Ok(log_path),
-        Err(e) => Err(e.description().to_string()),
+        Err(e) => Err(e.to_string()),
     }
 }
 /// Enable logging to rolling log files with Rust `log` library


### PR DESCRIPTION
Simplifies `e.description().to_string()` and `e.description().to_owned()` to just `e.to_string()`, which is much more flexible, widely supported, and _not_ deprecated :D