### PR TITLE
Update dirs crate to version 4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ dummy = []
 [dependencies]
 time = "0.1"
 log = {version = "0.4", optional = true, default-features = false, features = ["std"] }
-dirs = "2.0"
+dirs = "4"
 
 [dependencies.log4rs]
 version = "0.8"


### PR DESCRIPTION
This is a non-breaking change since the changes in the `dirs` crate don't affect the way we use it, but it does cause `dirs`'s dependencies to be updated, including `cfg-if` from v0.1.10 to v1.0.0, which most of the rest of the rust ecosystem including `wint` uses. This reduces dependency duplication in projects that use `fruitbasket`.